### PR TITLE
Fixed crash on invalid hash table

### DIFF
--- a/3rdparty/phnt/include/ntrtl.h
+++ b/3rdparty/phnt/include/ntrtl.h
@@ -30,14 +30,17 @@ FORCEINLINE BOOLEAN RemoveEntryList(
     _In_ PLIST_ENTRY Entry
     )
 {
-    PLIST_ENTRY Blink;
-    PLIST_ENTRY Flink;
+    if (!Entry) return FALSE;
 
-    Flink = Entry->Flink;
-    Blink = Entry->Blink;
+    PLIST_ENTRY Blink = Entry->Blink;
+    PLIST_ENTRY Flink = Entry->Flink;
+
+    if (!Blink || !Flink) return FALSE;
+
     Blink->Flink = Flink;
     Flink->Blink = Blink;
-
+    Entry->Flink = NULL;
+    Entry->Blink = NULL;
     return Flink == Blink;
 }
 

--- a/MemoryModule/LdrEntry.cpp
+++ b/MemoryModule/LdrEntry.cpp
@@ -272,9 +272,12 @@ NTSTATUS NTAPI RtlGetReferenceCount(
 VOID NTAPI RtlInsertMemoryTableEntry(_In_ PLDR_DATA_TABLE_ENTRY LdrEntry) {
 	PPEB_LDR_DATA PebData = NtCurrentPeb()->Ldr;
 	PLIST_ENTRY LdrpHashTable = MmpGlobalDataPtr->MmpLdrEntry->LdrpHashTable;
-	ULONG i;
+
+	/* Validate hash table */
+	if (!MmpGlobalDataPtr->MmpLdrEntry->LdrpHashTable) return;
 
 	/* Insert into hash table */
+	ULONG i;
 	i = LdrHashEntry(LdrEntry->BaseDllName);
 	InsertTailList(&LdrpHashTable[i], &LdrEntry->HashLinks);
 


### PR DESCRIPTION
Hi @bb107 
while using mmpp I faced a crash in my application on initialization when another dll was loaded. I investigated the issue and found the root, I applied a fix that made the application work perfectly however i'm not sure what is exactly the issue however the hashtable is null. by returning in will work later. You may want to check this and make a better fix.

also there was a crash on exit from ntrtl.h which the code doesn't make sense to me
```CPP
    Flink = Entry->Flink;
    Blink = Entry->Blink;
    Blink->Flink = Flink;
    Flink->Blink = Blink;
  ```

I fixed it by validation
```CPP
if (!Entry) return FALSE;
```

And I believe it must be
```CPP
    Blink->Flink = Flink;
    Flink->Blink = Blink;
    Entry->Flink = NULL;
    Entry->Blink = NULL;
  
```